### PR TITLE
Removed use of ternary operator for python 2.4

### DIFF
--- a/svn-color.py
+++ b/svn-color.py
@@ -45,7 +45,7 @@ def colorize(line):
 if __name__ == '__main__':
     command = sys.argv
     command[0] = '/usr/bin/svn'
-    subcommand = '' if len(command) < 2 else command[1]
+    subcommand = (command[1], '')[len(command) < 2]
     if subcommand in colorizedSubcommands and sys.stdout.isatty():
         task = subprocess.Popen(command, stdout=subprocess.PIPE)
         for line in task.stdout:


### PR DESCRIPTION
Had to use this sweet script on an RHEL5 installation, so I fixed it for Python 2.4.