### PR TITLE
In Python2, 'for' loop blocks until subprocess is ended.

### DIFF
--- a/svn-color.py
+++ b/svn-color.py
@@ -48,8 +48,12 @@ if __name__ == '__main__':
     subcommand = (command[1], '')[len(command) < 2]
     if subcommand in colorizedSubcommands and sys.stdout.isatty():
         task = subprocess.Popen(command, stdout=subprocess.PIPE)
-        for line in task.stdout:
+        while True:
+            line = task.stdout.readline()
+            if not line:
+                break
             sys.stdout.write(colorize(line))
+            sys.stdout.flush()
     else:
         task = subprocess.Popen(command)
     task.communicate()


### PR DESCRIPTION
If the output is short, this isn't an issue; but if the output is very
long, you won't be able to see realtime output until subproecess
terminates.

So intead use old fashioned while + readline to process realtime output.