### PR TITLE
Handle the case where there are zero arguments

### DIFF
--- a/svn-color.py
+++ b/svn-color.py
@@ -45,7 +45,11 @@ def colorize(line):
 if __name__ == '__main__':
     command = sys.argv
     command[0] = '/usr/bin/svn'
-    subcommand = (command[1], '')[len(command) < 2]
+    
+    if len(command) > 1:
+        subcommand = (command[1], '')[len(command) < 2]
+    else:
+        subcommand = ''
     if subcommand in colorizedSubcommands and sys.stdout.isatty():
         task = subprocess.Popen(command, stdout=subprocess.PIPE)
         while True:


### PR DESCRIPTION
It should also handle being run with no arguments, especially since it's encouraged to sit in place of svn. Before this change, it crashes.
